### PR TITLE
Pass through default configs

### DIFF
--- a/dagfactory/__version__.py
+++ b/dagfactory/__version__.py
@@ -1,3 +1,3 @@
 """Module contains the version of dag-factory"""
 
-__version__ = "0.19.0a1"
+__version__ = "0.19.0a2"

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -723,7 +723,6 @@ class DagBuilder:
         :type: Dict[str, Union[str, DAG]]
         """
         dag_params: Dict[str, Any] = self.get_dag_params()
-
         dag_kwargs: Dict[str, Any] = {}
 
         dag_kwargs["dag_id"] = dag_params["dag_id"]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1,4 +1,5 @@
 """Module contains code for generating tasks and constructing a DAG"""
+
 # pylint: disable=ungrouped-imports
 import os
 import re
@@ -198,34 +199,26 @@ class DagBuilder:
 
         if utils.check_dict_key(dag_params["default_args"], "sla_miss_callback"):
             if isinstance(dag_params["default_args"]["sla_miss_callback"], str):
-                dag_params["default_args"][
-                    "sla_miss_callback"
-                ]: Callable = import_string(
-                    dag_params["default_args"]["sla_miss_callback"]
+                dag_params["default_args"]["sla_miss_callback"]: Callable = (
+                    import_string(dag_params["default_args"]["sla_miss_callback"])
                 )
 
         if utils.check_dict_key(dag_params["default_args"], "on_success_callback"):
             if isinstance(dag_params["default_args"]["on_success_callback"], str):
-                dag_params["default_args"][
-                    "on_success_callback"
-                ]: Callable = import_string(
-                    dag_params["default_args"]["on_success_callback"]
+                dag_params["default_args"]["on_success_callback"]: Callable = (
+                    import_string(dag_params["default_args"]["on_success_callback"])
                 )
 
         if utils.check_dict_key(dag_params["default_args"], "on_failure_callback"):
             if isinstance(dag_params["default_args"]["on_failure_callback"], str):
-                dag_params["default_args"][
-                    "on_failure_callback"
-                ]: Callable = import_string(
-                    dag_params["default_args"]["on_failure_callback"]
+                dag_params["default_args"]["on_failure_callback"]: Callable = (
+                    import_string(dag_params["default_args"]["on_failure_callback"])
                 )
 
         if utils.check_dict_key(dag_params["default_args"], "on_retry_callback"):
             if isinstance(dag_params["default_args"]["on_retry_callback"], str):
-                dag_params["default_args"][
-                    "on_retry_callback"
-                ]: Callable = import_string(
-                    dag_params["default_args"]["on_retry_callback"]
+                dag_params["default_args"]["on_retry_callback"]: Callable = (
+                    import_string(dag_params["default_args"]["on_retry_callback"])
                 )
 
         if utils.check_dict_key(dag_params, "sla_miss_callback"):
@@ -358,11 +351,11 @@ class DagBuilder:
                         "  python_callable_file: !!python/name:my_module.my_func"
                     )
                 if not task_params.get("python_callable"):
-                    task_params[
-                        "python_callable"
-                    ]: Callable = utils.get_python_callable(
-                        task_params["python_callable_name"],
-                        task_params["python_callable_file"],
+                    task_params["python_callable"]: Callable = (
+                        utils.get_python_callable(
+                            task_params["python_callable_name"],
+                            task_params["python_callable_file"],
+                        )
                     )
                     # remove dag-factory specific parameters
                     # Airflow 2.0 doesn't allow these to be passed to operator
@@ -426,10 +419,10 @@ class DagBuilder:
                     del task_params["response_check_name"]
                     del task_params["response_check_file"]
                 else:
-                    task_params[
-                        "response_check"
-                    ]: Callable = utils.get_python_callable_lambda(
-                        task_params["response_check_lambda"]
+                    task_params["response_check"]: Callable = (
+                        utils.get_python_callable_lambda(
+                            task_params["response_check_lambda"]
+                        )
                     )
                     # remove dag-factory specific parameters
                     # Airflow 2.0 doesn't allow these to be passed to operator
@@ -676,18 +669,18 @@ class DagBuilder:
                 group_id = conf["task_group"].group_id
                 name = f"{group_id}.{name}"
             if conf.get("dependencies"):
-                source: Union[
-                    BaseOperator, "TaskGroup"
-                ] = tasks_and_task_groups_instances[name]
+                source: Union[BaseOperator, "TaskGroup"] = (
+                    tasks_and_task_groups_instances[name]
+                )
                 for dep in conf["dependencies"]:
                     if tasks_and_task_groups_config[dep].get("task_group"):
                         group_id = tasks_and_task_groups_config[dep][
                             "task_group"
                         ].group_id
                         dep = f"{group_id}.{dep}"
-                    dep: Union[
-                        BaseOperator, "TaskGroup"
-                    ] = tasks_and_task_groups_instances[dep]
+                    dep: Union[BaseOperator, "TaskGroup"] = (
+                        tasks_and_task_groups_instances[dep]
+                    )
                     source.set_upstream(dep)
 
     @staticmethod

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -12,6 +12,7 @@ from airflow.models import DAG
 
 from dagfactory.dagbuilder import DagBuilder
 from dagfactory.exceptions import DagFactoryConfigException, DagFactoryException
+from dagfactory.utils import merge_configs
 
 # these are params that cannot be a dag name
 SYSTEM_PARAMS: List[str] = ["default", "task_groups"]
@@ -45,8 +46,9 @@ class DagFactory:
         if config:
             self.config: Dict[str, Any] = config
 
-        if default_config and not self.config.get("default"):
-            self.config["default"] = default_config
+        self.config["default"] = merge_configs(
+                self.config.get("default", {}), default_config or {}
+            )
 
     @staticmethod
     def _validate_config_filepath(config_filepath: str) -> None:

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -29,7 +29,10 @@ class DagFactory:
     """
 
     def __init__(
-        self, config_filepath: Optional[str] = None, config: Optional[dict] = None
+        self,
+        config_filepath: Optional[str] = None,
+        config: Optional[dict] = None,
+        default_config: Optional[dict] = None
     ) -> None:
         assert bool(config_filepath) ^ bool(
             config
@@ -41,6 +44,9 @@ class DagFactory:
             )
         if config:
             self.config: Dict[str, Any] = config
+
+        if default_config and not self.config.get("default"):
+            self.config["default"] = default_config
 
     @staticmethod
     def _validate_config_filepath(config_filepath: str) -> None:
@@ -100,6 +106,7 @@ class DagFactory:
         """Build DAGs using the config file."""
         dag_configs: Dict[str, Dict[str, Any]] = self.get_dag_configs()
         default_config: Dict[str, Any] = self.get_default_config()
+        print(default_config)
 
         dags: Dict[str, Any] = {}
 
@@ -171,6 +178,7 @@ def load_yaml_dags(
     globals_dict: Dict[str, Any],
     dags_folder: str = airflow_conf.get("core", "dags_folder"),
     suffix=None,
+    default_config=None
 ):
     """
     Loads all the yaml/yml files in the dags folder
@@ -195,5 +203,5 @@ def load_yaml_dags(
 
     for config_file_path in candidate_dag_files:
         config_file_abs_path = str(config_file_path.absolute())
-        DagFactory(config_file_abs_path).generate_dags(globals_dict)
+        DagFactory(config_file_abs_path, default_config=default_config).generate_dags(globals_dict)
         logging.info("DAG loaded: %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -33,7 +33,7 @@ class DagFactory:
         self,
         config_filepath: Optional[str] = None,
         config: Optional[dict] = None,
-        default_config: Optional[dict] = None
+        default_config: Optional[dict] = None,
     ) -> None:
         assert bool(config_filepath) ^ bool(
             config
@@ -47,8 +47,8 @@ class DagFactory:
             self.config: Dict[str, Any] = config
 
         self.config["default"] = merge_configs(
-                self.config.get("default", {}), default_config or {}
-            )
+            self.config.get("default", {}), default_config or {}
+        )
 
     @staticmethod
     def _validate_config_filepath(config_filepath: str) -> None:
@@ -179,7 +179,7 @@ def load_yaml_dags(
     globals_dict: Dict[str, Any],
     dags_folder: str = airflow_conf.get("core", "dags_folder"),
     suffix=None,
-    default_config=None
+    default_config=None,
 ):
     """
     Loads all the yaml/yml files in the dags folder
@@ -204,5 +204,7 @@ def load_yaml_dags(
 
     for config_file_path in candidate_dag_files:
         config_file_abs_path = str(config_file_path.absolute())
-        DagFactory(config_file_abs_path, default_config=default_config).generate_dags(globals_dict)
+        DagFactory(config_file_abs_path, default_config=default_config).generate_dags(
+            globals_dict
+        )
         logging.info("DAG loaded: %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -106,7 +106,6 @@ class DagFactory:
         """Build DAGs using the config file."""
         dag_configs: Dict[str, Dict[str, Any]] = self.get_dag_configs()
         default_config: Dict[str, Any] = self.get_default_config()
-        print(default_config)
 
         dags: Dict[str, Any] = {}
 

--- a/tests/fixtures/dag_factory.yml
+++ b/tests/fixtures/dag_factory.yml
@@ -7,7 +7,7 @@ default:
     retries: 1
     retry_delay_sec: 300
     start_date: 2018-03-01
-  default_view: "tree"
+  default_view: tree
   max_active_runs: 1
   orientation: LR
   schedule_interval: 0 1 * * *
@@ -33,7 +33,7 @@ example_dag:
       - task_1
       operator: airflow.operators.bash_operator.BashOperator
 example_dag2:
-  doc_md_file_path: /Users/bensonlee/dev/dag-factory/tests/fixtures/mydocfile.md
+  doc_md_file_path: {here}/fixtures/mydocfile.md
   schedule_interval: None
   tasks:
     task_1:
@@ -53,7 +53,7 @@ example_dag3:
   doc_md_python_arguments:
     arg1: arg1
     arg2: arg2
-  doc_md_python_callable_file: /Users/bensonlee/dev/dag-factory/tests/fixtures/doc_md_builder.py
+  doc_md_python_callable_file: {here}/fixtures/doc_md_builder.py
   doc_md_python_callable_name: mydocmdbuilder
   tasks:
     task_1:

--- a/tests/fixtures/dag_factory_variables_as_arguments.yml
+++ b/tests/fixtures/dag_factory_variables_as_arguments.yml
@@ -9,7 +9,6 @@ default:
   max_active_runs: 1
   dagrun_timeout_sec: 600
   default_view: "tree"
-  orientation: 'LR'
   schedule_interval: '0 1 * * *'
 
 example_dag:

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -104,7 +104,7 @@ CUSTOM_DEFAULT_CONFIG = {
         "max_active_runs": 2,
         "dagrun_timeout_sec": 600,
         "default_view": "tree",
-        "orientation": "LR",
+        "orientation": "BT",
         "schedule_interval": "0 1 * * *",
     }
 
@@ -492,10 +492,15 @@ def test_load_yaml_dags_succeed():
         suffix=["dag_factory_variables_as_arguments.yml"],
     )
 
-def test_load_yaml_dags__with_default_succeed():
+def test_load_yaml_dags_with_default_succeed():
+    # only override missing default variables
+    g = globals()
     load_yaml_dags(
-        globals_dict=globals(),
+        globals_dict=g,
         dags_folder="tests/fixtures",
         suffix=["dag_factory_variables_as_arguments.yml"],
         default_config=CUSTOM_DEFAULT_CONFIG
     )
+
+    assert g['example_dag'].owner == 'custom_owner'
+    assert g['example_dag'].orientation == "BT"

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -499,4 +499,3 @@ def test_load_yaml_dags__with_default_succeed():
         suffix=["dag_factory_variables_as_arguments.yml"],
         default_config=CUSTOM_DEFAULT_CONFIG
     )
-    globals()['example_dag']


### PR DESCRIPTION
ability to load multiple dags from subfolders and pass in a default config.

```
from dagfactory import DagFactory, load_yaml_dags

default = {
  "default_args": {
    "owner": "yyy",
    "start_date": "2022-01-01",
    "retries": 3,
    "retry_delay_sec": 20
  },
  "concurrency": 5,
  "max_active_runs": 20,
  "dagrun_timeout_sec": 600,
  "default_view": "tree",
  "orientation": "LR",
  "schedule_interval": None,
  "catchup": False,
  "render_template_as_native_obj": False
}

load_yaml_dags(globals_dict=globals(), suffix=['dag.yaml'], default_config=default)
```